### PR TITLE
Move extension to contao/phpstan namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,25 +7,25 @@ This extension provides following features:
 
 * Provides correct return types for Contao services.
 
-[![Author](https://img.shields.io/badge/author-@1upgmbh-blue.svg?style=flat-square)](https://twitter.com/1upgmbh)
-[![Software License](https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square)](LICENSE)
-[![Travis CI](https://travis-ci.org/1up-lab/phpstan-contao.svg?style=flat-square&branch=master)](https://travis-ci.org/1up-lab/phpstan-contao)
-[![Coverage Status](https://coveralls.io/repos/github/1up-lab/phpstan-contao/badge.svg?style=flat-square&branch=master)](https://coveralls.io/github/1up-lab/phpstan-contao?branch=master)
-[![Total Downloads](https://poser.pugx.org/oneup/phpstan-contao/downloads?style=flat-square)](https://packagist.org/packages/oneup/phpstan-contao)
+[![](https://img.shields.io/travis/contao/phpstan/master.svg?style=flat-square)](https://travis-ci.org/contao/phpstan/)
+[![](https://img.shields.io/coveralls/contao/phpstan/master.svg?style=flat-square)](https://coveralls.io/github/contao/phpstan)
+[![](https://img.shields.io/packagist/v/contao/phpstan.svg?style=flat-square)](https://packagist.org/packages/contao/phpstan)
+[![](https://img.shields.io/packagist/dt/contao/phpstan.svg?style=flat-square)](https://packagist.org/packages/contao/phpstan)
+
 
 ## Usage
 
 To use this extension, require it in [Composer](https://getcomposer.org/):
 
 ```bash
-composer require --dev oneup/phpstan-contao
+composer require --dev contao/phpstan
 ```
 
 And include extension.neon in your project's PHPStan config:
 
 ```
 includes:
-    - vendor/oneup/phpstan-contao/extension.neon
+    - vendor/contao/phpstan/extension.neon
     - vendor/phpstan/phpstan-symfony/extension.neon
 
 parameters:
@@ -33,7 +33,7 @@ parameters:
         services_yml_path: %currentWorkingDirectory%/src/Resources/config/services.yml
 
     symfony:
-        container_xml_path: %currentWorkingDirectory%/vendor/oneup/phpstan-contao/var/cache/dev/appDevPHPStanProjectContainer.xml
+        container_xml_path: %currentWorkingDirectory%/vendor/contao/phpstan/var/cache/dev/appDevPHPStanProjectContainer.xml
 ```
 
 ## Limitations

--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,8 @@
     ],
     "require": {
         "php": "^7.1",
+        "friendsofsymfony/http-cache": "^2.4",
+        "friendsofsymfony/http-cache-bundle": "^2.3",
         "phpstan/phpstan": "^0.10.2",
         "phpstan/phpstan-symfony": "^0.10",
         "symfony/debug": "^4.1",

--- a/composer.json
+++ b/composer.json
@@ -1,50 +1,45 @@
 {
-  "name": "oneup/phpstan-contao",
-  "description": "Contao Framework extensions and rules for PHPStan",
-  "license": "MIT",
-  "authors": [
-    {
-      "name": "David Greminger",
-      "homepage": "https://github.com/bytehead"
-    }
-  ],
-  "require": {
-    "php": "^7.1",
-    "phpstan/phpstan": "^0.10.2",
-    "phpstan/phpstan-symfony": "^0.10",
-    "symfony/debug": "^4.1",
-    "symfony/monolog-bundle": "^3.3",
-    "symfony/monolog-bridge": "^3.0 || ^4.0",
-    "symfony/templating": "^3.1 || ^4.0"
-  },
-  "require-dev": {
-    "contao/core-bundle": "^4.5.999",
-    "contao/test-case": "^1.1",
-    "friendsofphp/php-cs-fixer": "^2.12",
-    "lexik/maintenance-bundle": "^2.1.3",
-    "php-coveralls/php-coveralls": "^2.1",
-    "php-http/guzzle6-adapter": "^1.1",
-    "phpunit/phpunit": "^7.2",
-    "symfony/var-dumper": "^4.1"
-  },
-  "config": {
-    "sort-packages": true
-  },
-  "autoload": {
-    "psr-4": {
-      "Oneup\\PHPStan\\": "src/"
-    }
-  },
-  "autoload-dev": {
-    "psr-4": {
-      "Oneup\\PHPStan\\Tests\\": "tests/"
-    }
-  },
-  "minimum-stability": "dev",
-  "prefer-stable": true,
-  "support": {
-    "email": "hello@1up.io",
-    "issues": "https://github.com/1up-lab/phpstan-contao/issues",
-    "source": "https://github.com/1up-lab/phpstan-contao"
-  }
+    "name": "contao/phpstan",
+    "description": "Contao Framework extensions and rules for PHPStan",
+    "license": "LGPL-3.0-or-later",
+    "authors": [
+        {
+            "name": "David Greminger",
+            "homepage": "https://github.com/bytehead"
+        }
+    ],
+    "require": {
+        "php": "^7.1",
+        "phpstan/phpstan": "^0.10.2",
+        "phpstan/phpstan-symfony": "^0.10",
+        "symfony/debug": "^4.1",
+        "symfony/monolog-bridge": "^3.0 || ^4.0",
+        "symfony/monolog-bundle": "^3.3",
+        "symfony/templating": "^3.1 || ^4.0"
+    },
+    "require-dev": {
+        "contao/core-bundle": "^4.5.999",
+        "contao/test-case": "^1.1",
+        "friendsofphp/php-cs-fixer": "^2.12",
+        "lexik/maintenance-bundle": "^2.1.3",
+        "php-coveralls/php-coveralls": "^2.1",
+        "php-http/guzzle6-adapter": "^1.1",
+        "phpunit/phpunit": "^7.2",
+        "symfony/var-dumper": "^4.1"
+    },
+    "config": {
+        "sort-packages": true
+    },
+    "autoload": {
+        "psr-4": {
+            "Contao\\PHPStan\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Contao\\PHPStan\\Tests\\": "tests/"
+        }
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
 }

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,6 @@
     ],
     "require": {
         "php": "^7.1",
-        "friendsofsymfony/http-cache": "^2.4",
         "friendsofsymfony/http-cache-bundle": "^2.3",
         "phpstan/phpstan": "^0.10.2",
         "phpstan/phpstan-symfony": "^0.10",

--- a/composer.json
+++ b/composer.json
@@ -33,12 +33,12 @@
     },
     "autoload": {
         "psr-4": {
-            "Contao\\PHPStan\\": "src/"
+            "Contao\\PhpStan\\": "src/"
         }
     },
     "autoload-dev": {
         "psr-4": {
-            "Contao\\PHPStan\\Tests\\": "tests/"
+            "Contao\\PhpStan\\Tests\\": "tests/"
         }
     },
     "minimum-stability": "dev",

--- a/extension.neon
+++ b/extension.neon
@@ -1,26 +1,26 @@
 services:
     -
-        class: Oneup\PHPStan\Type\Contao\ContainerInterfaceDynamicMethodReturnTypeExtension
+        class: Contao\PHPStan\Type\Contao\ContainerInterfaceDynamicMethodReturnTypeExtension
         tags:
             - phpstan.broker.dynamicMethodReturnTypeExtension
     -
-        class: Oneup\PHPStan\Type\Contao\ContainerAwareInterfaceDynamicMethodReturnTypeExtension
-        tags:
-            - phpstan.broker.dynamicMethodReturnTypeExtension
-
-    -
-        class: Oneup\PHPStan\Type\Contao\ContaoFrameworkDynamicMethodReturnTypeExtension
+        class: Contao\PHPStan\Type\Contao\ContainerAwareInterfaceDynamicMethodReturnTypeExtension
         tags:
             - phpstan.broker.dynamicMethodReturnTypeExtension
 
     -
-        class: Oneup\PHPStan\Type\Contao\ContaoTestCaseDynamicMethodReturnTypeExtension
+        class: Contao\PHPStan\Type\Contao\ContaoFrameworkDynamicMethodReturnTypeExtension
         tags:
             - phpstan.broker.dynamicMethodReturnTypeExtension
 
     -
-        class: Oneup\PHPStan\Reflection\Contao\BackendTemplateClassReflectionExtension
+        class: Contao\PHPStan\Type\Contao\ContaoTestCaseDynamicMethodReturnTypeExtension
+        tags:
+            - phpstan.broker.dynamicMethodReturnTypeExtension
+
+    -
+        class: Contao\PHPStan\Reflection\Contao\BackendTemplateClassReflectionExtension
         tags:
             - phpstan.broker.propertiesClassReflectionExtension
 
-    - Oneup\PHPStan\Contao\ServiceHelper(%contao.services_yml_path%)
+    - Contao\PHPStan\Contao\ServiceHelper(%contao.services_yml_path%)

--- a/src/AppKernel.php
+++ b/src/AppKernel.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Contao\PHPStan;
+namespace Contao\PhpStan;
 
 use Contao\CoreBundle\ContaoCoreBundle;
 use Doctrine\Bundle\DoctrineBundle\DoctrineBundle;

--- a/src/AppKernel.php
+++ b/src/AppKernel.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Oneup\PHPStan;
+namespace Contao\PHPStan;
 
 use Contao\CoreBundle\ContaoCoreBundle;
 use Doctrine\Bundle\DoctrineBundle\DoctrineBundle;

--- a/src/Reflection/BackendTemplateClassReflectionExtension.php
+++ b/src/Reflection/BackendTemplateClassReflectionExtension.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Contao\PHPStan\Reflection;
+namespace Contao\PhpStan\Reflection;
 
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\PropertiesClassReflectionExtension;

--- a/src/Reflection/BackendTemplateClassReflectionExtension.php
+++ b/src/Reflection/BackendTemplateClassReflectionExtension.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Oneup\PHPStan\Reflection\Contao;
+namespace Contao\PHPStan\Reflection;
 
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\PropertiesClassReflectionExtension;

--- a/src/Reflection/BackendTemplateReflection.php
+++ b/src/Reflection/BackendTemplateReflection.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Contao\PHPStan\Reflection;
+namespace Contao\PhpStan\Reflection;
 
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\PropertyReflection;

--- a/src/Reflection/BackendTemplateReflection.php
+++ b/src/Reflection/BackendTemplateReflection.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Oneup\PHPStan\Reflection\Contao;
+namespace Contao\PHPStan\Reflection;
 
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\PropertyReflection;

--- a/src/Service.php
+++ b/src/Service.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Oneup\PHPStan\Contao;
+namespace Contao\PHPStan;
 
 final class Service
 {

--- a/src/Service.php
+++ b/src/Service.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Contao\PHPStan;
+namespace Contao\PhpStan;
 
 final class Service
 {

--- a/src/ServiceHelper.php
+++ b/src/ServiceHelper.php
@@ -2,9 +2,8 @@
 
 declare(strict_types=1);
 
-namespace Oneup\PHPStan\Contao;
+namespace Contao\PHPStan;
 
-use Oneup\PHPStan\AppKernel;
 use PhpParser\Node\Expr;
 use PHPStan\Analyser\Scope;
 use PHPStan\Type\TypeUtils;

--- a/src/ServiceHelper.php
+++ b/src/ServiceHelper.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Contao\PHPStan;
+namespace Contao\PhpStan;
 
 use PhpParser\Node\Expr;
 use PHPStan\Analyser\Scope;

--- a/src/Type/AbstractDynamicMethodReturnTypeFromServiceHelperExtension.php
+++ b/src/Type/AbstractDynamicMethodReturnTypeFromServiceHelperExtension.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace Contao\PHPStan\Type;
+namespace Contao\PhpStan\Type;
 
-use Contao\PHPStan\Service;
-use Contao\PHPStan\ServiceHelper;
+use Contao\PhpStan\Service;
+use Contao\PhpStan\ServiceHelper;
 use PhpParser\Node\Expr\MethodCall;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\MethodReflection;

--- a/src/Type/AbstractDynamicMethodReturnTypeFromServiceHelperExtension.php
+++ b/src/Type/AbstractDynamicMethodReturnTypeFromServiceHelperExtension.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace Oneup\PHPStan\Type\Contao;
+namespace Contao\PHPStan\Type;
 
-use Oneup\PHPStan\Contao\Service;
-use Oneup\PHPStan\Contao\ServiceHelper;
+use Contao\PHPStan\Service;
+use Contao\PHPStan\ServiceHelper;
 use PhpParser\Node\Expr\MethodCall;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\MethodReflection;

--- a/src/Type/ContainerAwareInterfaceDynamicMethodReturnTypeExtension.php
+++ b/src/Type/ContainerAwareInterfaceDynamicMethodReturnTypeExtension.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Oneup\PHPStan\Type\Contao;
+namespace Contao\PHPStan\Type;
 
 use PHPStan\Reflection\MethodReflection;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;

--- a/src/Type/ContainerAwareInterfaceDynamicMethodReturnTypeExtension.php
+++ b/src/Type/ContainerAwareInterfaceDynamicMethodReturnTypeExtension.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Contao\PHPStan\Type;
+namespace Contao\PhpStan\Type;
 
 use PHPStan\Reflection\MethodReflection;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;

--- a/src/Type/ContainerInterfaceDynamicMethodReturnTypeExtension.php
+++ b/src/Type/ContainerInterfaceDynamicMethodReturnTypeExtension.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Contao\PHPStan\Type;
+namespace Contao\PhpStan\Type;
 
 use PHPStan\Reflection\MethodReflection;
 use Symfony\Component\DependencyInjection\ContainerInterface;

--- a/src/Type/ContainerInterfaceDynamicMethodReturnTypeExtension.php
+++ b/src/Type/ContainerInterfaceDynamicMethodReturnTypeExtension.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Oneup\PHPStan\Type\Contao;
+namespace Contao\PHPStan\Type;
 
 use PHPStan\Reflection\MethodReflection;
 use Symfony\Component\DependencyInjection\ContainerInterface;

--- a/src/Type/ContaoFrameworkDynamicMethodReturnTypeExtension.php
+++ b/src/Type/ContaoFrameworkDynamicMethodReturnTypeExtension.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Contao\PHPStan\Type;
+namespace Contao\PhpStan\Type;
 
 use Contao\CoreBundle\Framework\ContaoFramework;
 use PhpParser\Node\Arg;

--- a/src/Type/ContaoFrameworkDynamicMethodReturnTypeExtension.php
+++ b/src/Type/ContaoFrameworkDynamicMethodReturnTypeExtension.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Oneup\PHPStan\Type\Contao;
+namespace Contao\PHPStan\Type;
 
-use Contao\TestCase\ContaoTestCase;
+use Contao\CoreBundle\Framework\ContaoFramework;
 use PhpParser\Node\Arg;
 use PhpParser\Node\Expr\ClassConstFetch;
 use PhpParser\Node\Expr\MethodCall;
@@ -12,21 +12,19 @@ use PhpParser\Node\Name;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\Type\DynamicMethodReturnTypeExtension;
-use PHPStan\Type\IntersectionType;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
-use PHPUnit\Framework\MockObject\MockObject;
 
-class ContaoTestCaseDynamicMethodReturnTypeExtension implements DynamicMethodReturnTypeExtension
+class ContaoFrameworkDynamicMethodReturnTypeExtension implements DynamicMethodReturnTypeExtension
 {
     public function getClass(): string
     {
-        return ContaoTestCase::class;
+        return ContaoFramework::class;
     }
 
     public function isMethodSupported(MethodReflection $methodReflection): bool
     {
-        return 'mockClassWithProperties' === $methodReflection->getName();
+        return 'createInstance' === $methodReflection->getName();
     }
 
     public function getTypeFromMethodCall(MethodReflection $methodReflection, MethodCall $methodCall, Scope $scope): Type
@@ -36,11 +34,7 @@ class ContaoTestCaseDynamicMethodReturnTypeExtension implements DynamicMethodRet
             $value = $argument->value;
 
             if ($value instanceof ClassConstFetch && $value->class instanceof Name) {
-                // see https://medium.com/@ondrejmirtes/union-types-vs-intersection-types-fd44a8eacbb
-                return new IntersectionType([
-                    new ObjectType((string) $value->class),
-                    new ObjectType(MockObject::class),
-                ]);
+                return new ObjectType((string) $value->class);
             }
         }
 

--- a/src/Type/ContaoTestCaseDynamicMethodReturnTypeExtension.php
+++ b/src/Type/ContaoTestCaseDynamicMethodReturnTypeExtension.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Contao\PHPStan\Type;
+namespace Contao\PhpStan\Type;
 
 use Contao\TestCase\ContaoTestCase;
 use PhpParser\Node\Arg;

--- a/src/Type/ContaoTestCaseDynamicMethodReturnTypeExtension.php
+++ b/src/Type/ContaoTestCaseDynamicMethodReturnTypeExtension.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Oneup\PHPStan\Type\Contao;
+namespace Contao\PHPStan\Type;
 
-use Contao\CoreBundle\Framework\ContaoFramework;
+use Contao\TestCase\ContaoTestCase;
 use PhpParser\Node\Arg;
 use PhpParser\Node\Expr\ClassConstFetch;
 use PhpParser\Node\Expr\MethodCall;
@@ -12,19 +12,21 @@ use PhpParser\Node\Name;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\Type\DynamicMethodReturnTypeExtension;
+use PHPStan\Type\IntersectionType;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
+use PHPUnit\Framework\MockObject\MockObject;
 
-class ContaoFrameworkDynamicMethodReturnTypeExtension implements DynamicMethodReturnTypeExtension
+class ContaoTestCaseDynamicMethodReturnTypeExtension implements DynamicMethodReturnTypeExtension
 {
     public function getClass(): string
     {
-        return ContaoFramework::class;
+        return ContaoTestCase::class;
     }
 
     public function isMethodSupported(MethodReflection $methodReflection): bool
     {
-        return 'createInstance' === $methodReflection->getName();
+        return 'mockClassWithProperties' === $methodReflection->getName();
     }
 
     public function getTypeFromMethodCall(MethodReflection $methodReflection, MethodCall $methodCall, Scope $scope): Type
@@ -34,7 +36,11 @@ class ContaoFrameworkDynamicMethodReturnTypeExtension implements DynamicMethodRe
             $value = $argument->value;
 
             if ($value instanceof ClassConstFetch && $value->class instanceof Name) {
-                return new ObjectType((string) $value->class);
+                // see https://medium.com/@ondrejmirtes/union-types-vs-intersection-types-fd44a8eacbb
+                return new IntersectionType([
+                    new ObjectType((string) $value->class),
+                    new ObjectType(MockObject::class),
+                ]);
             }
         }
 

--- a/tests/ServiceHelperTest.php
+++ b/tests/ServiceHelperTest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Contao\PHPStan\Tests;
+
+use Contao\PHPStan\ServiceHelper;
+use PHPUnit\Framework\TestCase;
+
+class ServiceHelperTest extends TestCase
+{
+    public function testCanBeInstantiated(): void
+    {
+        $serviceHelper = new ServiceHelper(__DIR__.'/Resources/config/empty_services.yml');
+
+        $this->assertInstanceOf('Contao\PHPStan\ServiceHelper', $serviceHelper);
+    }
+
+    public function testEmptyServicesYml(): void
+    {
+        $serviceHelper = new ServiceHelper(__DIR__.'/Resources/config/empty_services.yml');
+
+        $this->assertNull($serviceHelper->getService('foobar.id'));
+    }
+}

--- a/tests/ServiceHelperTest.php
+++ b/tests/ServiceHelperTest.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Contao\PHPStan\Tests;
+namespace Contao\PhpStan\Tests;
 
-use Contao\PHPStan\ServiceHelper;
+use Contao\PhpStan\ServiceHelper;
 use PHPUnit\Framework\TestCase;
 
 class ServiceHelperTest extends TestCase
@@ -13,7 +13,7 @@ class ServiceHelperTest extends TestCase
     {
         $serviceHelper = new ServiceHelper(__DIR__.'/Resources/config/empty_services.yml');
 
-        $this->assertInstanceOf('Contao\PHPStan\ServiceHelper', $serviceHelper);
+        $this->assertInstanceOf('Contao\PhpStan\ServiceHelper', $serviceHelper);
     }
 
     public function testEmptyServicesYml(): void

--- a/tests/ServiceTest.php
+++ b/tests/ServiceTest.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Contao\PHPStan\Tests;
+namespace Contao\PhpStan\Tests;
 
-use Contao\PHPStan\Service;
+use Contao\PhpStan\Service;
 use PHPUnit\Framework\TestCase;
 
 class ServiceTest extends TestCase
@@ -25,7 +25,7 @@ class ServiceTest extends TestCase
 
     public function testCanBeInstantiated(): void
     {
-        $this->assertInstanceOf('Contao\PHPStan\Service', $this->service);
+        $this->assertInstanceOf('Contao\PhpStan\Service', $this->service);
     }
 
     public function testReturnsValidId(): void

--- a/tests/ServiceTest.php
+++ b/tests/ServiceTest.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Oneup\PHPStan\Tests\Contao;
+namespace Contao\PHPStan\Tests;
 
-use Oneup\PHPStan\Contao\Service;
+use Contao\PHPStan\Service;
 use PHPUnit\Framework\TestCase;
 
 class ServiceTest extends TestCase
@@ -25,7 +25,7 @@ class ServiceTest extends TestCase
 
     public function testCanBeInstantiated(): void
     {
-        $this->assertInstanceOf('Oneup\PHPStan\Contao\Service', $this->service);
+        $this->assertInstanceOf('Contao\PHPStan\Service', $this->service);
     }
 
     public function testReturnsValidId(): void


### PR DESCRIPTION
Refactored extension for the new space over at [`contao/phpstan`](https://github.com/contao/phpstan).

**TODO after merge:**
- [ ] move this repository to [`contao/phpstan`](https://github.com/contao/phpstan)
- [ ] release version `0.3.0`
- [ ] merge https://github.com/contao/contao/pull/23

/cc @leofeyer 